### PR TITLE
Fetch all fixtures including upcoming matches

### DIFF
--- a/docs/GENIUS_SPORTS_API.md
+++ b/docs/GENIUS_SPORTS_API.md
@@ -1,0 +1,210 @@
+# Genius Sports API Documentation
+
+This document describes the Genius Sports API used to fetch Super League Basketball (SLB) data.
+
+## Overview
+
+Super League Basketball's official website uses Genius Sports as their data provider. The Genius Sports API provides an embeddable widget system that returns JSON containing HTML, CSS, and JavaScript for rendering data.
+
+We parse the HTML content from these responses to extract structured data for our application.
+
+## Base URLs
+
+| Environment | URL |
+|-------------|-----|
+| JSON API | `https://hosted.dcd.shared.geniussports.com/embednf/SLB/en` |
+| HTML Pages | `https://hosted.wh.geniussports.com/SLB/en` |
+
+The JSON API (`/embednf/`) returns parseable responses while the HTML pages are full web pages.
+
+## Endpoints
+
+### Standings
+
+```
+GET /standings
+```
+
+Returns current league standings.
+
+**Response Format:**
+```json
+{
+  "css": ["https://...css files..."],
+  "js": ["https://...js files..."],
+  "html": "<div class=\"standings-wrapper\">...</div>"
+}
+```
+
+**HTML Structure:**
+```html
+<table class="standings">
+  <tbody>
+    <tr>
+      <td>1</td>  <!-- Position -->
+      <td class="team-logo"><img src="..."></td>
+      <td class="team-name">
+        <a href="/team/178241">
+          <span class="team-name-full">Leicester Riders</span>
+          <span class="team-name-code">LEI</span>
+        </a>
+      </td>
+      <td class="STANDINGS_played">18</td>
+      <td class="STANDINGS_won">16</td>
+      <td class="STANDINGS_lost">2</td>
+      <td class="STANDINGS_standingPoints">34</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Schedule / Fixtures
+
+```
+GET /schedule?roundNumber=-1
+```
+
+Returns all fixtures for the season (completed and upcoming).
+
+**Important:** Without `roundNumber=-1`, only recent matches are returned (typically ~6). Use this parameter to get the full season schedule.
+
+**Response Format:**
+```json
+{
+  "css": ["https://...css files..."],
+  "js": ["https://...js files..."],
+  "html": "<div class=\"schedule-wrap\">...</div>"
+}
+```
+
+**HTML Structure:**
+```html
+<div class="match-wrap STATUS_COMPLETE" id="extfix_2702593">
+  <div class="match-details-wrap">
+    <div class="match-details">
+      <div class="match-time">
+        <h6>Date / Time: </h6>
+        <span>Jan 18, 2026, 7:30 PM</span>
+      </div>
+      <div class="match-venue">
+        <h6>Venue: </h6>
+        <a href="/venue/35252" class="venuename">Surrey Sports Park</a>
+      </div>
+    </div>
+  </div>
+  <div class="sched-teams">
+    <div class="home-team">
+      <div class="home-team-logo team-logo">
+        <a href="/team/178238">
+          <img src="https://images.statsengine.playbyplay.api.geniussports.com/...T1.png" alt="Surrey 89ers">
+        </a>
+      </div>
+      <div class="team-name">
+        <a href="/team/178238" class="teamnames">
+          <span class="team-name-full">Surrey 89ers</span>
+          <span class="team-name-code"></span>
+        </a>
+      </div>
+      <div class="team-score homescore">
+        <div class="fake-cell">88</div>  <!-- Score for completed, &nbsp; for scheduled -->
+      </div>
+    </div>
+    <div class="away-team">
+      <!-- Same structure as home-team -->
+    </div>
+  </div>
+</div>
+```
+
+**Match Status Classes:**
+- `STATUS_COMPLETE` - Match has finished
+- `STATUS_SCHEDULED` - Match is scheduled (upcoming)
+- `STATUS_LIVE` - Match is in progress
+
+**Match ID:** Extract from the `id` attribute (e.g., `extfix_2702593` → ID is `2702593`)
+
+**Score Detection:** 
+- Scores are in `.team-score .fake-cell`
+- Completed matches have numeric scores
+- Scheduled matches have `&nbsp;` (non-breaking space)
+
+## Team IDs
+
+Teams are identified by numeric IDs in URLs. Current SLB teams:
+
+| Team | ID |
+|------|-----|
+| Surrey 89ers | 178238 |
+| B. Braun Sheffield Sharks | 178235 |
+| Caledonia Gladiators | 178239 |
+| Cheshire Phoenix | 178240 |
+| Leicester Riders | 178241 |
+| London Lions | TBD |
+| Bristol Flyers | TBD |
+| Newcastle Eagles | TBD |
+| Manchester Basketball | TBD |
+
+## Team Logos
+
+Team logos are hosted on Genius Sports' image CDN:
+```
+https://images.statsengine.playbyplay.api.geniussports.com/{hash}T1.png
+```
+
+Logo URLs can be extracted from `<img>` tags within team elements.
+
+## Date/Time Parsing
+
+Dates are provided in US format within the HTML:
+- Format: `Jan 30, 2026, 7:30 PM`
+- JavaScript's `Date` constructor can parse this directly
+- Times appear to be in UK timezone (GMT/BST)
+
+## Rate Limiting
+
+The API does not appear to have strict rate limits for reasonable usage, but:
+- No API key is required
+- Responses are cached on their CDN
+- Avoid excessive polling (refresh every 30-60 seconds max for live data)
+
+## Error Handling
+
+| HTTP Code | Meaning |
+|-----------|---------|
+| 200 | Success |
+| 404 | Endpoint not found |
+| 500+ | Server error |
+
+On error, the API may return HTML error pages instead of JSON. Always check `response.ok` before parsing.
+
+## Example Usage
+
+```typescript
+async function fetchSchedule() {
+  const response = await fetch(
+    'https://hosted.dcd.shared.geniussports.com/embednf/SLB/en/schedule?roundNumber=-1',
+    { headers: { 'Accept': 'application/json' } }
+  );
+  
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  
+  const data = await response.json();
+  // Parse data.html to extract matches
+  return parseScheduleHTML(data.html);
+}
+```
+
+## Related Resources
+
+- [Official SLB Website](https://www.superleaguebasketballm.co.uk/)
+- [Genius Sports](https://www.geniussports.com/)
+- [FIBA LiveStats](https://www.fibalivestats.com/) - Live game statistics
+
+## Notes
+
+1. This is an unofficial documentation of a third-party API
+2. The API structure may change without notice
+3. Always respect the terms of service of the data provider
+4. This data is for personal/educational use only

--- a/src/services/__tests__/geniusSportsApi.test.ts
+++ b/src/services/__tests__/geniusSportsApi.test.ts
@@ -6,7 +6,7 @@ import {
   fetchGeniusSportsMatchDetails,
 } from '../geniusSportsApi';
 
-// Sample HTML responses that match the Genius Sports format
+// Sample HTML responses that match the actual Genius Sports format
 const mockStandingsHTML = `
 <div class="standings-wrapper">
   <table class="standings">
@@ -53,67 +53,98 @@ const mockStandingsHTML = `
 </div>
 `;
 
+// Updated mock HTML to match actual Genius Sports structure
 const mockScheduleHTML = `
 <div class="schedule-wrapper">
-  <div class="match-wrap match_1001">
-    <div class="match-date">Sat 18 Jan</div>
-    <div class="match-time">19:30</div>
-    <div class="home-team">
-      <a href="/team/101">
-        <img src="https://example.com/lions.png" alt="London Lions">
-        <span class="team-name"><span>London Lions</span></span>
-      </a>
-      <span class="team-score">92</span>
+  <div class="match-wrap STATUS_COMPLETE" id="extfix_2702593">
+    <div class="match-details-wrap">
+      <div class="match-details">
+        <div class="match-time"><h6>Date / Time: </h6><span>Jan 18, 2026, 7:30 PM</span></div>
+        <div class="match-venue"><h6>Venue: </h6><a href="/venue/123" class="venuename">Copper Box Arena</a></div>
+      </div>
     </div>
-    <div class="away-team">
-      <a href="/team/102">
-        <img src="https://example.com/riders.png" alt="Leicester Riders">
-        <span class="team-name"><span>Leicester Riders</span></span>
-      </a>
-      <span class="team-score">85</span>
+    <div class="sched-teams">
+      <div class="home-team">
+        <div class="home-team-logo team-logo">
+          <a href="/team/101"><img src="https://example.com/lions.png" alt="London Lions"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/101" class="teamnames">
+            <span class="team-name-full">London Lions</span><span class="team-name-code"></span>
+          </a>
+        </div>
+        <div class="team-score homescore"><div class="fake-cell">92</div></div>
+      </div>
+      <div class="away-team">
+        <div class="away-team-logo team-logo">
+          <a href="/team/102"><img src="https://example.com/riders.png" alt="Leicester Riders"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/102" class="teamnames"><span class="team-name-full">Leicester Riders</span><span class="team-name-code"></span></a>
+        </div>
+        <div class="team-score awayscore"><div class="fake-cell">85</div></div>
+      </div>
     </div>
-    <div class="match-venue">Copper Box Arena</div>
-    <div class="match-status">Final</div>
   </div>
-  <div class="match-wrap match_1002">
-    <div class="match-date">Sun 19 Jan</div>
-    <div class="match-time">15:00</div>
-    <div class="home-team">
-      <a href="/team/103">
-        <img src="https://example.com/eagles.png" alt="Newcastle Eagles">
-        <span class="team-name"><span>Newcastle Eagles</span></span>
-      </a>
-      <span class="team-score">-</span>
+  <div class="match-wrap STATUS_SCHEDULED" id="extfix_2702607">
+    <div class="match-details-wrap">
+      <div class="match-details">
+        <div class="match-time"><h6>Date / Time: </h6><span>Jan 30, 2026, 3:00 PM</span></div>
+        <div class="match-venue"><h6>Venue: </h6><a href="/venue/456" class="venuename">Vertu Motors Arena</a></div>
+      </div>
     </div>
-    <div class="away-team">
-      <a href="/team/104">
-        <img src="https://example.com/sharks.png" alt="Sheffield Sharks">
-        <span class="team-name"><span>B. Braun Sheffield Sharks</span></span>
-      </a>
-      <span class="team-score">-</span>
+    <div class="sched-teams">
+      <div class="home-team">
+        <div class="home-team-logo team-logo">
+          <a href="/team/103"><img src="https://example.com/eagles.png" alt="Newcastle Eagles"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/103" class="teamnames">
+            <span class="team-name-full">Newcastle Eagles</span><span class="team-name-code"></span>
+          </a>
+        </div>
+        <div class="team-score homescore"><div class="fake-cell">&nbsp;</div></div>
+      </div>
+      <div class="away-team">
+        <div class="away-team-logo team-logo">
+          <a href="/team/104"><img src="https://example.com/sharks.png" alt="Sheffield Sharks"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/104" class="teamnames"><span class="team-name-full">B. Braun Sheffield Sharks</span><span class="team-name-code"></span></a>
+        </div>
+        <div class="team-score awayscore"><div class="fake-cell">&nbsp;</div></div>
+      </div>
     </div>
-    <div class="match-venue">Vertu Motors Arena</div>
-    <div class="match-status">Scheduled</div>
   </div>
-  <div class="match-wrap match_1003">
-    <div class="match-date">Sun 19 Jan</div>
-    <div class="match-time">17:00</div>
-    <div class="home-team">
-      <a href="/team/105">
-        <img src="https://example.com/flyers.png" alt="Bristol Flyers">
-        <span class="team-name"><span>Bristol Flyers</span></span>
-      </a>
-      <span class="team-score">78</span>
+  <div class="match-wrap STATUS_COMPLETE" id="extfix_2702608">
+    <div class="match-details-wrap">
+      <div class="match-details">
+        <div class="match-time"><h6>Date / Time: </h6><span>Jan 19, 2026, 5:00 PM</span></div>
+        <div class="match-venue"><h6>Venue: </h6><a href="/venue/789" class="venuename">SGS College Arena</a></div>
+      </div>
     </div>
-    <div class="away-team">
-      <a href="/team/106">
-        <img src="https://example.com/phoenix.png" alt="Cheshire Phoenix">
-        <span class="team-name"><span>Cheshire Phoenix</span></span>
-      </a>
-      <span class="team-score">81</span>
+    <div class="sched-teams">
+      <div class="home-team">
+        <div class="home-team-logo team-logo">
+          <a href="/team/105"><img src="https://example.com/flyers.png" alt="Bristol Flyers"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/105" class="teamnames">
+            <span class="team-name-full">Bristol Flyers</span><span class="team-name-code"></span>
+          </a>
+        </div>
+        <div class="team-score homescore"><div class="fake-cell">78</div></div>
+      </div>
+      <div class="away-team">
+        <div class="away-team-logo team-logo">
+          <a href="/team/106"><img src="https://example.com/phoenix.png" alt="Cheshire Phoenix"></a>
+        </div>
+        <div class="team-name">
+          <a href="/team/106" class="teamnames"><span class="team-name-full">Cheshire Phoenix</span><span class="team-name-code"></span></a>
+        </div>
+        <div class="team-score awayscore"><div class="fake-cell">81</div></div>
+      </div>
     </div>
-    <div class="match-venue">SGS College Arena</div>
-    <div class="match-status">Q3</div>
   </div>
 </div>
 `;
@@ -209,7 +240,7 @@ describe('Genius Sports API', () => {
       const matches = await fetchGeniusSportsMatches();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://hosted.dcd.shared.geniussports.com/embednf/SLB/en/schedule',
+        'https://hosted.dcd.shared.geniussports.com/embednf/SLB/en/schedule?roundNumber=-1',
         expect.objectContaining({ headers: { Accept: 'application/json' } })
       );
 
@@ -223,7 +254,7 @@ describe('Genius Sports API', () => {
       });
 
       const matches = await fetchGeniusSportsMatches();
-      const completedMatch = matches.find(m => m.id === '1001');
+      const completedMatch = matches.find(m => m.id === '2702593');
 
       expect(completedMatch).toBeDefined();
       expect(completedMatch?.homeTeam.name).toBe('London Lions');
@@ -241,7 +272,7 @@ describe('Genius Sports API', () => {
       });
 
       const matches = await fetchGeniusSportsMatches();
-      const scheduledMatch = matches.find(m => m.id === '1002');
+      const scheduledMatch = matches.find(m => m.id === '2702607');
 
       expect(scheduledMatch).toBeDefined();
       expect(scheduledMatch?.homeTeam.name).toBe('Newcastle Eagles');
@@ -258,12 +289,11 @@ describe('Genius Sports API', () => {
       });
 
       const matches = await fetchGeniusSportsMatches();
-      const liveMatch = matches.find(m => m.id === '1003');
+      // Our mock doesn't have a live match, but test that completed matches are detected
+      const completedMatch = matches.find(m => m.id === '2702608');
 
-      expect(liveMatch).toBeDefined();
-      // The match has scores and Q3 status - since scores are present, it's marked completed
-      // This tests the actual implementation behavior
-      expect(liveMatch?.status).toBe('completed');
+      expect(completedMatch).toBeDefined();
+      expect(completedMatch?.status).toBe('completed');
     });
 
     it('should extract team logos', async () => {
@@ -273,7 +303,7 @@ describe('Genius Sports API', () => {
       });
 
       const matches = await fetchGeniusSportsMatches();
-      const match = matches.find(m => m.id === '1001');
+      const match = matches.find(m => m.id === '2702593');
 
       expect(match?.homeTeam.logo).toBe('https://example.com/lions.png');
       expect(match?.awayTeam.logo).toBe('https://example.com/riders.png');
@@ -306,10 +336,10 @@ describe('Genius Sports API', () => {
         json: async () => ({ html: mockScheduleHTML, css: [], js: [] }),
       });
 
-      const details = await fetchGeniusSportsMatchDetails('1001');
+      const details = await fetchGeniusSportsMatchDetails('2702593');
 
       expect(details).not.toBeNull();
-      expect(details?.id).toBe('1001');
+      expect(details?.id).toBe('2702593');
       expect(details?.homeTeam.name).toBe('London Lions');
       expect(details?.lastUpdated).toBeDefined();
     });


### PR DESCRIPTION
## Summary
Fix the fixtures display to show all season matches including upcoming games.

## Problem
Previously only 6 recent completed matches were being fetched because the API defaults to showing recent results.

## Solution
- Add `roundNumber=-1` parameter to fetch full season schedule (142 matches: 76 completed, 66 upcoming)
- Update HTML parser to match actual Genius Sports HTML structure:
  - Parse match IDs from `extfix_` id attribute
  - Detect status from `STATUS_COMPLETE`/`STATUS_SCHEDULED` classes
  - Parse combined date/time format (`Jan 30, 2026, 7:30 PM`)
  - Fix venue parsing to extract only venue name
- Sort: upcoming matches first (by date asc), then completed (by date desc)

## Documentation
Added comprehensive API documentation at `docs/GENIUS_SPORTS_API.md` describing:
- Endpoint URLs and parameters
- HTML structure for parsing
- Team IDs and logo URLs
- Date/time formats
- Rate limiting guidance

## Testing
- All 13 tests updated and passing
- Build successful