### PR TITLE
feat: Add SLB Trophy competition support

### DIFF
--- a/docs/GENIUS_SPORTS_API.md
+++ b/docs/GENIUS_SPORTS_API.md
@@ -17,15 +17,34 @@ We parse the HTML content from these responses to extract structured data for ou
 
 The JSON API (`/embednf/`) returns parseable responses while the HTML pages are full web pages.
 
+## Competition IDs
+
+SLB has multiple competitions, each with a unique ID:
+
+| Competition | ID | Description |
+|-------------|-----|-------------|
+| Championship | `41897` | Regular season (32 games per team) |
+| Trophy | `42212` | Group stage + knockout tournament |
+| Cup | `47714` | Knockout tournament |
+| Playoffs | TBD | Top 8 knockout (created closer to May) |
+
+**Important:** Each competition has its own schedule and standings. Trophy and Cup matches are **not** included in the main Championship schedule.
+
 ## Endpoints
 
 ### Standings
 
 ```
 GET /standings
+GET /competition/{competitionId}/standings
 ```
 
-Returns current league standings.
+Returns current league standings. Use the competition-specific endpoint for Trophy/Cup standings.
+
+**Examples:**
+- Championship: `/standings` or `/competition/41897/standings`
+- Trophy: `/competition/42212/standings` (group standings)
+- Cup: `/competition/47714/standings` (empty - knockout format)
 
 **Response Format:**
 ```json
@@ -62,11 +81,17 @@ Returns current league standings.
 
 ```
 GET /schedule?roundNumber=-1
+GET /competition/{competitionId}/schedule?roundNumber=-1
 ```
 
-Returns all fixtures for the season (completed and upcoming).
+Returns all fixtures for the competition (completed and upcoming).
 
 **Important:** Without `roundNumber=-1`, only recent matches are returned (typically ~6). Use this parameter to get the full season schedule.
+
+**Examples:**
+- Championship: `/schedule?roundNumber=-1` (~145 matches)
+- Trophy: `/competition/42212/schedule?roundNumber=-1` (~15 matches)
+- Cup: `/competition/47714/schedule?roundNumber=-1` (~10 matches)
 
 **Response Format:**
 ```json

--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -13,23 +13,42 @@ export interface LeagueConfig extends League {
   apiProvider: ApiProvider;
   /** Competition code for EuroLeague API (E = EuroLeague, U = EuroCup) */
   competitionCode?: string;
+  /** Competition ID for Genius Sports API (SLB competitions) */
+  geniusSportsCompetitionId?: string;
 }
 
 // League IDs for internal use
 export const LEAGUE_IDS = {
   SUPER_LEAGUE: 'super-league',
+  SLB_TROPHY: 'slb-trophy',
   EUROLEAGUE: 'euroleague',
   EUROCUP: 'eurocup',
+} as const;
+
+// Genius Sports competition IDs for SLB
+export const SLB_COMPETITION_IDS = {
+  CHAMPIONSHIP: '41897',
+  TROPHY: '42212',
+  CUP: '47714',
 } as const;
 
 // Predefined leagues with their API configurations
 export const predefinedLeagues: LeagueConfig[] = [
   {
     id: LEAGUE_IDS.SUPER_LEAGUE,
-    name: 'Super League Basketball',
-    shortName: 'Super League',
+    name: 'SLB Championship',
+    shortName: 'Championship',
     country: 'England',
-    apiProvider: 'geniussports', // Official SLB data via Genius Sports
+    apiProvider: 'geniussports',
+    geniusSportsCompetitionId: SLB_COMPETITION_IDS.CHAMPIONSHIP,
+  },
+  {
+    id: LEAGUE_IDS.SLB_TROPHY,
+    name: 'SLB Trophy',
+    shortName: 'Trophy',
+    country: 'England',
+    apiProvider: 'geniussports',
+    geniusSportsCompetitionId: SLB_COMPETITION_IDS.TROPHY,
   },
   {
     id: LEAGUE_IDS.EUROLEAGUE,


### PR DESCRIPTION
## Summary

Adds support for tracking the **SLB Trophy** competition alongside the existing Championship.

## Changes

### `src/services/leagues.ts`
- Added `SLB_TROPHY` to `LEAGUE_IDS`
- Added `SLB_COMPETITION_IDS` constant with Championship (`41897`), Trophy (`42212`), and Cup (`47714`) IDs
- Added `geniusSportsCompetitionId` to `LeagueConfig` interface
- Added Trophy as a selectable league

### `src/services/geniusSportsApi.ts`
- Updated all fetch functions to accept optional `competitionId` parameter
- Uses competition-specific endpoints for Trophy (`/competition/42212/...`)
- Maintains backward compatibility with default Championship ID

### `src/services/dataProvider.ts`
- Updated to pass `geniusSportsCompetitionId` from league config to API functions
- Match detail lookup now searches all SLB competitions (Championship, Trophy, Cup)

### `docs/GENIUS_SPORTS_API.md`
- Added Competition IDs section documenting all SLB competitions
- Updated endpoint examples to show competition-specific usage

## Testing

- ✅ All 31 tests pass
- ✅ Build succeeds
- ✅ Verified Trophy endpoint returns 15 matches
- ✅ Verified Trophy standings endpoint works

## API Endpoints Used

| Competition | Fixtures | Standings |
|-------------|----------|-----------|
| Championship | `/schedule?roundNumber=-1` | `/standings` |
| Trophy | `/competition/42212/schedule?roundNumber=-1` | `/competition/42212/standings` |

Closes #34