### PR TITLE
feat: Add SLB Cup competition support

### DIFF
--- a/src/services/leagues.ts
+++ b/src/services/leagues.ts
@@ -21,6 +21,7 @@ export interface LeagueConfig extends League {
 export const LEAGUE_IDS = {
   SUPER_LEAGUE: 'super-league',
   SLB_TROPHY: 'slb-trophy',
+  SLB_CUP: 'slb-cup',
   EUROLEAGUE: 'euroleague',
   EUROCUP: 'eurocup',
 } as const;
@@ -49,6 +50,14 @@ export const predefinedLeagues: LeagueConfig[] = [
     country: 'England',
     apiProvider: 'geniussports',
     geniusSportsCompetitionId: SLB_COMPETITION_IDS.TROPHY,
+  },
+  {
+    id: LEAGUE_IDS.SLB_CUP,
+    name: 'SLB Cup',
+    shortName: 'Cup',
+    country: 'England',
+    apiProvider: 'geniussports',
+    geniusSportsCompetitionId: SLB_COMPETITION_IDS.CUP,
   },
   {
     id: LEAGUE_IDS.EUROLEAGUE,


### PR DESCRIPTION
## Summary

Adds support for tracking the **SLB Cup** competition.

## Changes

Just 9 lines in `src/services/leagues.ts`:
- Added `SLB_CUP` to `LEAGUE_IDS`
- Added Cup league config with competition ID `47714`

Infrastructure was already in place from Trophy PR (#37).

## Testing

- ✅ All 31 tests pass
- ✅ Build succeeds

Closes #35